### PR TITLE
PulseAudio: Use default sink at multiple sink environment

### DIFF
--- a/volume_linux.go
+++ b/volume_linux.go
@@ -48,8 +48,6 @@ func getPADefaultSink() (string, error) {
 	return "", errors.New("Could not find PulseAudio Default Sink")
 }
 
-var volumePattern = regexp.MustCompile(`\d+%`)
-
 func parseVolume(out string) (int, error) {
 	sinkName, sinkNameErr := getPADefaultSink()
 
@@ -60,6 +58,7 @@ func parseVolume(out string) (int, error) {
 	}
 
 	lines := strings.Split(out, "\n")
+	volumePattern := regexp.MustCompile(`\d+%`)
 
 	for _, line := range lines {
 		s := strings.TrimLeft(line, " \t")

--- a/volume_linux.go
+++ b/volume_linux.go
@@ -48,7 +48,7 @@ func setVolumeCmd(volume int) []string {
 	if useAmixer {
 		return []string{"amixer", "set", "Master", strconv.Itoa(volume) + "%"}
 	}
-	return []string{"pactl", "set-sink-volume", "0", strconv.Itoa(volume) + "%"}
+	return []string{"pactl", "set-sink-volume", "@DEFAULT_SINK@", strconv.Itoa(volume) + "%"}
 }
 
 func increaseVolumeCmd(diff int) []string {
@@ -62,7 +62,7 @@ func increaseVolumeCmd(diff int) []string {
 	if useAmixer {
 		return []string{"amixer", "set", "Master", strconv.Itoa(diff) + "%" + sign}
 	}
-	return []string{"pactl", "--", "set-sink-volume", "0", sign + strconv.Itoa(diff) + "%"}
+	return []string{"pactl", "--", "set-sink-volume", "@DEFAULT_SINK@", sign + strconv.Itoa(diff) + "%"}
 }
 
 func getMutedCmd() []string {
@@ -92,12 +92,12 @@ func muteCmd() []string {
 	if useAmixer {
 		return []string{"amixer", "-D", "pulse", "set", "Master", "mute"}
 	}
-	return []string{"pactl", "set-sink-mute", "0", "1"}
+	return []string{"pactl", "set-sink-mute", "@DEFAULT_SINK@", "1"}
 }
 
 func unmuteCmd() []string {
 	if useAmixer {
 		return []string{"amixer", "-D", "pulse", "set", "Master", "unmute"}
 	}
-	return []string{"pactl", "set-sink-mute", "0", "0"}
+	return []string{"pactl", "set-sink-mute", "@DEFAULT_SINK@", "0"}
 }

--- a/volume_linux.go
+++ b/volume_linux.go
@@ -53,10 +53,10 @@ var volumePattern = regexp.MustCompile(`\d+%`)
 func parseVolume(out string) (int, error) {
 	sinkName, sinkNameErr := getPADefaultSink()
 
-	pa_default_sink_hooked := false
+	paDefaultSinkHooked := false
 
 	if sinkNameErr != nil {
-		pa_default_sink_hooked = true
+		paDefaultSinkHooked = true
 	}
 
 	lines := strings.Split(out, "\n")
@@ -65,11 +65,11 @@ func parseVolume(out string) (int, error) {
 		s := strings.TrimLeft(line, " \t")
 
 		if !useAmixer && strings.Contains(s, "Name: "+string(sinkName)) {
-			pa_default_sink_hooked = true
+			paDefaultSinkHooked = true
 		}
 
 		if useAmixer && strings.Contains(s, "Playback") && strings.Contains(s, "%") ||
-			!useAmixer && pa_default_sink_hooked && strings.HasPrefix(s, "Volume:") {
+			!useAmixer && paDefaultSinkHooked && strings.HasPrefix(s, "Volume:") {
 			volumeStr := volumePattern.FindString(s)
 			return strconv.Atoi(volumeStr[:len(volumeStr)-1])
 		}
@@ -108,10 +108,10 @@ func getMutedCmd() []string {
 func parseMuted(out string) (bool, error) {
 	sinkName, sinkNameErr := getPADefaultSink()
 
-	pa_default_sink_hooked := false
+	paDefaultSinkHooked := false
 
 	if sinkNameErr != nil {
-		pa_default_sink_hooked = true
+		paDefaultSinkHooked = true
 	}
 
 	lines := strings.Split(out, "\n")
@@ -119,11 +119,11 @@ func parseMuted(out string) (bool, error) {
 		s := strings.TrimLeft(line, " \t")
 
 		if !useAmixer && strings.Contains(s, "Name: "+string(sinkName)) {
-			pa_default_sink_hooked = true
+			paDefaultSinkHooked = true
 		}
 
 		if useAmixer && strings.Contains(s, "Playback") && strings.Contains(s, "%") ||
-			!useAmixer && pa_default_sink_hooked && strings.HasPrefix(s, "Mute: ") {
+			!useAmixer && paDefaultSinkHooked && strings.HasPrefix(s, "Mute: ") {
 			if strings.Contains(s, "[off]") || strings.Contains(s, "yes") {
 				return true, nil
 			} else if strings.Contains(s, "[on]") || strings.Contains(s, "no") {


### PR DESCRIPTION
At the original code, A PulseAudio command forced to use sink 0 for controlling/fetching volume.
The following changes allow using default sink at multiple audio sink environments. (mostly user selected on their gui/ in the case of only one sink available, pa will use it as default sink ) 
 
- Use @DEFAULT_SINK@ for `pactl set-sink*` commands instead of sink 0. 
- Use `pactl info` to fetch default sink.  