### PR TITLE
Rename package imported for Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/go-ole/go-ole v1.2.4
-	github.com/moutend/go-wca v0.1.1
+	github.com/moutend/go-wca v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/moutend/go-wca v0.1.1 h1:XTuNIhTOxRrdOQnCufXdTAp2+Nh3vtE7upKksC31sS4=
-github.com/moutend/go-wca v0.1.1/go.mod h1:tOejf27SfSMa+8LuMhPE0bdaFNnoxlmMGvo/VwAWi7Q=
+github.com/moutend/go-wca v0.2.0 h1:AEzY6ltC5zPCldKyMYdyXv3TaLqwxSW1TIradqNqRpU=
+github.com/moutend/go-wca v0.2.0/go.mod h1:L/ka++dPvkHYz0UuQ/PIQ3aTuecoXOIM1RSAesh6RYU=

--- a/volume_windows.go
+++ b/volume_windows.go
@@ -5,7 +5,7 @@ import (
 	"math"
 
 	"github.com/go-ole/go-ole"
-	"github.com/moutend/go-wca"
+	"github.com/moutend/go-wca/pkg/wca"
 )
 
 // GetVolume returns the current volume (0 to 100).


### PR DESCRIPTION
The go-wca package probably moved around, causing this package to be not installable.
Tested on Windows 10 20H4